### PR TITLE
on_message wrapper and cleanup

### DIFF
--- a/Jarvis/jarvis.py
+++ b/Jarvis/jarvis.py
@@ -105,7 +105,7 @@ class Jarvis:
         print("| Connection Established - Jarvis is in the houuuse! |")
         print("------------------------------------------------------")
 
-    def on_close(self, connection, close_status_code, close_msg):
+    def on_close(self, connection):
         # Called when websocket connection is closed.
         print("------------------------------------------------------")
         print("| Jarvis disconnected - See ya later alligator :)    |") 
@@ -167,6 +167,9 @@ if __name__ == '__main__':
 
     # Initiate Jarvis
     jarvis = Jarvis()
+
+    def on_message_wrapper(connection, message):
+        jarvis.on_message(connection, message)
 
     # Enable/Disable debugging messages for websocket:
     #   1) Enable  -> True


### PR DESCRIPTION
added message wrapper after initiating jarvis and removed extra arguments from 'on_close'.

on_message_wrapper() fixed the error Yoshi was having (and hopefully will fix Ted's). This was what her friend Erik suggested.

Removing the last 2 arguments for on_close() made the closing message work for me without errors.